### PR TITLE
Add default values in the generated file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,22 @@ And just run:
 jsonschema-gentypes
 ```
 
+# Default
+
+The default values are exported in the Python file, then you can do something like that:
+
+```python
+value_with_default = my_object.get('field_name', my_schema.FIELD_DEFAULT)
+```
+
 # Validation
 
 This package also provide some validations features for YAML file based on `jsonschema`.
 
 Additional features:
 
-- Have the line and columns number in the errors, it the file is loaded with `ruamel.yaml`.
-- Fill with the default provides in the JSON schema, disabled by default because it have some issue with `OneOf` and `AnyOf`.
+- Obtain the line and columns number in the errors, if the file is loaded with `ruamel.yaml`.
+- Export the default provided in the JSON schema.
 
 ```python
     import ruamel.yaml
@@ -73,11 +81,14 @@ Additional features:
     with open(filename) as data_file:
         yaml = ruamel.yaml.YAML()  # type: ignore
         data = yaml.load(data_file)
-    errors, data = jsonschema_gentypes.validate.validate(filename, data, schema, default)
+    errors, data = jsonschema_gentypes.validate.validate(filename, data, schema)
     if errors:
         print("\n".join(errors))
         sys.exit(1)
 ```
+
+The filling of the default value is deprecated because it can produce quite peculiar things, see also
+[the jsonschema documentation](https://python-jsonschema.readthedocs.io/en/stable/faq/#why-doesn-t-my-schema-s-default-property-set-the-default-on-my-instance).
 
 ## Limitations
 

--- a/jsonschema_gentypes/jsonschema.py
+++ b/jsonschema_gentypes/jsonschema.py
@@ -5,6 +5,10 @@ Automatically generated file from a JSON schema.
 
 from typing import Any, Dict, List, Literal, TypedDict, Union
 
+# Default value of the field path 'JSONSchema'
+CORE_SCHEMA_META_SCHEMA_DEFAULT = True
+
+
 # Core schema meta-schema
 #
 # default: True
@@ -105,6 +109,42 @@ JSONSchemaItem = TypedDict(
     },
     total=False,
 )
+
+
+# Default value of the field path 'Core schema meta-schema object definitions'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_DEFINITIONS_DEFAULT: Any = {}
+
+
+# Default value of the field path 'Core schema meta-schema object items'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_ITEMS_DEFAULT = True
+
+
+# Default value of the field path 'Core schema meta-schema object minLength allof1'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_MINLENGTH_ALLOF1_DEFAULT = 0
+
+
+# Default value of the field path 'Core schema meta-schema object patternProperties'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_PATTERNPROPERTIES_DEFAULT: Any = {}
+
+
+# Default value of the field path 'Core schema meta-schema object properties'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_PROPERTIES_DEFAULT: Any = {}
+
+
+# Default value of the field path 'Core schema meta-schema object readOnly'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_READONLY_DEFAULT = False
+
+
+# Default value of the field path 'Core schema meta-schema object required'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_REQUIRED_DEFAULT: Any = []
+
+
+# Default value of the field path 'Core schema meta-schema object uniqueItems'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_UNIQUEITEMS_DEFAULT = False
+
+
+# Default value of the field path 'Core schema meta-schema object writeOnly'
+_CORE_SCHEMA_META_SCHEMA_OBJECT_WRITEONLY_DEFAULT = False
 
 
 # WARNING: Forward references may not be supported.

--- a/jsonschema_gentypes/validate.py
+++ b/jsonschema_gentypes/validate.py
@@ -5,6 +5,7 @@ Module that offer some useful functions to validate the data against a JSON sche
 import logging
 import re
 from typing import Any, Dict, Iterator, List, Optional, Tuple
+from warnings import warn
 
 import jsonschema
 
@@ -92,6 +93,9 @@ def validate(
         jsonschema.Draft7Validator,
     )
     if default:
+        warn(
+            "This is deprecated, use `obj.get('field', schema.FIELD_TYPE_DEFAULT)` instead.", DeprecationWarning
+        )
         Validator = _extend_with_default(  # noqa: N806 # variable 'Validator' in function should be lowercase
             Validator
         )

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -535,13 +535,36 @@ TESTBASICTYPES_FALSE: Literal[False] = False"""
 def test_default(value, expected_type) -> None:
     type_ = get_types({"title": "test basic types", "default": value})
     assert (
-        "\n".join([d.rstrip() for d in type_.definition(None)])
+        "\n".join([d.rstrip() for d in type_.depends_on()[0].definition(None)])
         == f"""
 
 # test basic types
 #
 # default: {value}
 TestBasicTypes = {expected_type}"""
+    )
+
+
+@pytest.mark.parametrize(
+    "value,expected_type",
+    [
+        (11, " = 11"),
+        (1.1, " = 1.1"),
+        (True, " = True"),
+        ("test", " = 'test'"),
+        (None, " = None"),
+        ([111], ": Any = [111]"),
+        ({"aa": 111}, ": Any = {'aa': 111}"),
+    ],
+)
+def test_default(value, expected_type) -> None:
+    type_ = get_types({"title": "test basic types", "type": "string", "default": value})
+    assert (
+        "\n".join([d.rstrip() for d in type_.depends_on()[-1].definition(None)])
+        == f"""
+
+# Default value of the field path 'Base'
+TEST_BASIC_TYPES_DEFAULT{expected_type}"""
     )
 
 


### PR DESCRIPTION
e.-g. here: https://python-jsonschema.readthedocs.io/en/stable/faq/#why-doesn-t-my-schema-s-default-property-set-the-default-on-my-instance
it's explained that the validator shouldn't fill the values with the default.

Then we deprecated it, and export them to be able to do:
```python
odj.get('field', schema.fieldDefault)
```